### PR TITLE
Fix: segfault with GCC's optimization

### DIFF
--- a/main.c
+++ b/main.c
@@ -26,7 +26,7 @@ int main(int argc, char **argv){
   FILE *fp = fopen(argv[1], "r");
   if(fp!=NULL){
     unsigned int v[] = VARIENT;
-    unsigned int vs = sizeof(v)/sizeof(*(v)), vi;
+    unsigned int vs = sizeof(v)/sizeof(*(v)), vi = 0;
     char c;
     while( c!=EOF ) {
       getch();


### PR DESCRIPTION
Passing `-O2` or `-O3` optimization creates segfault because (unsigned int) `vi`  is used to indexing `v` but here `vi` value isn't declared. It seems like when GCC optimization (`-O2` or `-O3`) s enabled it doesn't set `vi` value to `0` and as a result, the program terminates with a segfault.

With `-Os` optimization `vi ` value set to `0`, according to it `xorl	%r13d, %r13d`, so with this flag it will not end up with a segfault. Explicitly setting `vi` value to `0` will fix it.